### PR TITLE
Better Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,34 +2,57 @@
 # https://makefiletutorial.com/#implicit-rules
 # https://renenyffenegger.ch/notes/development/languages/C-C-plus-plus/GCC/create-libraries/index
 # https://stackoverflow.com/questions/2649334/difference-between-static-and-shared-libraries
-exec := texture.cpp# or main.cpp
-LIB_NAME := lib.a
+exec      = texture # name of the executable selected when doing 'run'
 
-LIB_DIR := ./lib
-SRC_DIR := ./src
-BUILD_DIR :=./build
+SRC_DIR   = src
+BUILD_DIR = build
 
-CPP_FILES := $(shell find $(LIB_DIR) -name '*.cpp')
-BUILD_CPP_FILES := $(CPP_FILES:%=$(BUILD_DIR)/%.o)
+LIB_DIR   = lib/viewer_core
+LIB_NAME  = lib.a
 
-LIBS=-lGL -lX11 -lpthread -lXrandr -ldl -lglfw -lGLEW -lGLU
-INCLUDES=./include
-STD=-std=c++17
+LIB_SRC = $(shell find $(LIB_DIR) -name '*.cpp')
+LIB_OBJ = $(LIB_SRC:%=$(BUILD_DIR)/%.o)
+DEPS    = $(LIB_OBJ:%.o=%.d)
 
-# build archive, need object files
-lib: $(BUILD_CPP_FILES)
-	ar rcs $(BUILD_DIR)/$(LIB_NAME) $^ 
+SRC   = $(shell find $(SRC_DIR) -name '*.cpp')
+OBJ   = $(SRC:%=$(BUILD_DIR)/$(SRC_DIR)/%.o)
+DEPS += $(OBJ:%.o=%.d)
+BINS  = $(foreach file, $(SRC), $(BUILD_DIR)/$(shell basename $(file) .cpp).out)
 
-bin: lib 
-	$(CXX) $(STD) $(SRC_DIR)/$(exec) -L$(BUILD_DIR) -l:$(LIB_NAME) -I$(INCLUDES) $(CPPFLAGS) $(CXXFLAGS) $(LIBS) -o $(BUILD_DIR)/$(exec).out
+CXXFLAGS += -std=c++17 -Iinclude
+CXXFLAGS += `pkg-config --cflags glew`
+CXXFLAGS += `pkg-config --cflags glfw3`
+CXXFLAGS += `pkg-config --cflags xrandr`
 
-# build object files
-$(BUILD_DIR)/%.cpp.o: %.cpp
-	mkdir -p $(dir $@)
-	$(CXX) $(STD) $(CPPFLAGS) $(CXXFLAGS) -I$(INCLUDES) -c $< -o $@ 
+LDFLAGS  += `pkg-config --libs glew`
+LDFLAGS  += `pkg-config --libs glfw3`
+LDFLAGS  += `pkg-config --libs xrandr`
+LDFLAGS  += -lpthread
 
+.PHONY: all
+all: $(BINS)
+
+.PHONY: bin
+bin: $(BUILD_DIR)/$(exec).out
+
+.PHONY: run
+run: bin
+	$(BUILD_DIR)/$(exec).out
+
+.PHONY: clean
 clean: 
 	rm -rf $(BUILD_DIR)
 
-run: bin
-	$(BUILD_DIR)/$(exec).out
+# build archive, need object files
+$(BUILD_DIR)/$(LIB_NAME): $(LIB_OBJ)
+	ar rcs $@ $^ 
+
+$(BUILD_DIR)/%.out: $(BUILD_DIR)/$(SRC_DIR)/%.cpp.o $(BUILD_DIR)/$(LIB_NAME)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $< $(BUILD_DIR)/$(LIB_NAME)
+
+-include $(DEPS)
+
+# build object files
+$(BUILD_DIR)/%.cpp.o: %.cpp
+	-@mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) -MMD -MP -c $< -o $@


### PR DESCRIPTION
This is a better Makefile where things are quite automated. Primarly, I added a `all` target that is default and which builds every binaries. I also added dependency rules on headers, which is neat when modifying a private header for the library.

With all these modifications, you can choose which binary you want to execute with the `run` target by doing: `make run exec=<name>`.